### PR TITLE
Add --clean option to remove migration files

### DIFF
--- a/django_unmigrate/core.py
+++ b/django_unmigrate/core.py
@@ -27,7 +27,7 @@ def get_targets(database="default", ref=MAIN_BRANCH):
     Produce target migrations from ``database`` and ``ref``.
     """
     added_targets = get_added_migrations(ref)
-    return get_parents_from_targets(added_targets, database)
+    return (added_targets, get_parents_from_targets(added_targets, database))
 
 
 def get_added_migrations(ref=MAIN_BRANCH):
@@ -62,7 +62,6 @@ def get_parents_from_targets(targets, database="default"):
     connection = connections[database]
     connection.prepare_database()
     loader = MigrationLoader(connection)
-    executor = MigrationExecutor(connection)
     plan_dict = {target: set(loader.graph.backwards_plan(target)) for target in targets}
     final_targets = []
     # Detecting overlapping plans

--- a/django_unmigrate/core.py
+++ b/django_unmigrate/core.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-from django.conf import settings
 from django.db import connections
-from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.loader import MigrationLoader
 
 from git import Repo

--- a/dunm_sandbox/tests/test_core.py
+++ b/dunm_sandbox/tests/test_core.py
@@ -47,5 +47,6 @@ class GetTargetsTestCase(TestCase):
             expected_parents = []
             if expected_migrations:
                 expected_parents = PARENTS[expected_migrations[0]]
-            targets = get_targets(ref=commit)
-            self.assertEqual(set(targets), set(expected_parents))
+            (added_targets, parent_target) = get_targets(ref=commit)
+            self.assertEqual(set(added_targets), set(expected_migrations))
+            self.assertEqual(set(parent_target), set(expected_parents))


### PR DESCRIPTION
Here is my initial stab at solving https://github.com/lorinkoz/django-unmigrate/issues/10. In 3.7+ I would probably create a `dataclass` to wrap up all of the nested tuples, but didn't want to make that many changes just for this functionality. Let me know if it doesn't make sense, or you have any questions!