### PR TITLE
Minor fixes in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ With ``django-unmigrate`` you can speed up the process.
 Usage
 -----
 
-Add ``django-unmigrate`` to your ``INSTALLED_APPS``. This is required to make
+Add ``django_unmigrate`` to your ``INSTALLED_APPS``. This is required to make
 the ``unmigrate`` management command available.
 
 Then, while standing on any branch, you will be able to use::


### PR DESCRIPTION
Replace `django-unmigrate` with `django_unmigrate` for `INSTALLED_APPS`.